### PR TITLE
Create useCurrentRoom hook

### DIFF
--- a/src/hooks/useCurrentRoom/useCurrentRoom.tsx
+++ b/src/hooks/useCurrentRoom/useCurrentRoom.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import useMapItems from '../useSync/useMapItems';
+import { useAppState } from '../../state';
+
+// Returns the object of the party room the current user is in
+export default function useCurrentRoom() {
+  const users = useMapItems('users');
+  const rooms = useMapItems('rooms');
+  const { user } = useAppState();
+  const [currentRoom, setCurrentRoom] = useState(null);
+
+  useEffect(() => {
+    if (user && users && rooms) {
+      const userRoomId = users[user.uid]?.room;
+      const newCurrentRoom = rooms[userRoomId];
+      setCurrentRoom(newCurrentRoom);
+    }
+  }, [rooms, user, users]);
+
+  return currentRoom;
+}


### PR DESCRIPTION
## Summary
- This creates the `useCurrentRoom` hook that allows us to get the object of the room the current user is in

## Tests
- [x] locally tested with a console log
- [ ] Adding specs

## Reviewers
@carlosdp 