### PR TITLE
Create room info popover

### DIFF
--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -1,19 +1,17 @@
-import React, { ChangeEvent, FormEvent, useState, useEffect } from 'react';
+import React from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 import AppBar from '@material-ui/core/AppBar';
-import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import TextField from '@material-ui/core/TextField';
 import ToggleFullscreenButton from '../ToggleFullScreenButton/ToggleFullScreenButton';
+import RoomInfoButtonAndPopOver from './RoomInfoButtonAndPopOver/RoomInfoButtonAndPopOver';
 import Toolbar from '@material-ui/core/Toolbar';
 import Menu from './Menu/Menu';
 
 import { useAppState } from '../../state';
-import { useParams } from 'react-router-dom';
 import useRoomState from '../../hooks/useRoomState/useRoomState';
-import useVideoContext from '../../hooks/useVideoContext/useVideoContext';
 import { Typography } from '@material-ui/core';
+import useCurrentRoom from '../../hooks/useCurrentRoom/useCurrentRoom';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -44,8 +42,14 @@ export default function MenuBar() {
   const classes = useStyles();
   const { user } = useAppState();
   const roomState = useRoomState();
+  const usersCurrentRoom = useCurrentRoom();
 
-  const roomName = 'Room Name Here';
+  const roomName =
+    usersCurrentRoom?.name == null ? (
+      <CircularProgress color="secondary" size={18} />
+    ) : (
+      <span>{usersCurrentRoom?.name}</span>
+    );
 
   return (
     <AppBar className={classes.container} position="static">
@@ -54,6 +58,7 @@ export default function MenuBar() {
           {user?.displayName}
         </Typography>
         {roomState !== 'disconnected' ? <h3>{roomName}</h3> : null}
+        {usersCurrentRoom && <RoomInfoButtonAndPopOver />}
         <ToggleFullscreenButton />
         <Menu />
       </Toolbar>

--- a/src/components/MenuBar/RoomInfoButtonAndPopOver/RoomInfoButtonAndPopOver.tsx
+++ b/src/components/MenuBar/RoomInfoButtonAndPopOver/RoomInfoButtonAndPopOver.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { styled } from '@material-ui/core';
+import useCurrentRoom from '../../../hooks/useCurrentRoom/useCurrentRoom';
+import PopOverWithButton, { BUTTON_TYPE_INFO } from '../../shared/PopOverWithButton/PopOverWithButton';
+
+const IconContainer = styled('div')(({ theme }) => ({
+  marginLeft: theme.spacing(1.5),
+}));
+
+const RoomRulesTitle = styled('div')({
+  color: '#F2F2F2',
+  fontSize: '20px',
+  fontWeight: 600,
+  lineHeight: '24px',
+});
+
+const RoomRulesContent = styled('div')({
+  color: '#BEBEBE',
+  fontSize: '16px',
+  marginTop: 0,
+});
+
+export default function RoomInfoButtonAndPopOver() {
+  const currentRoom = useCurrentRoom();
+  const roomTitle = currentRoom?.name ? `Rules for the ${currentRoom.name}` : 'Room rules';
+  const roomDescription = currentRoom?.description || 'No description was provided...this is a mystery room.';
+
+  return (
+    <IconContainer>
+      <PopOverWithButton buttonType={BUTTON_TYPE_INFO} popOverId="room-info-popover">
+        <RoomRulesTitle>{roomTitle}</RoomRulesTitle>
+        <RoomRulesContent>{roomDescription}</RoomRulesContent>
+      </PopOverWithButton>
+    </IconContainer>
+  );
+}

--- a/src/components/shared/PopOverWithButton/PopOverWithButton.tsx
+++ b/src/components/shared/PopOverWithButton/PopOverWithButton.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Popover from '@material-ui/core/Popover';
+import Button from '@material-ui/core/Button';
+import InfoIcon from '@material-ui/icons/Info';
+import { CardActionArea, styled } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  popOverOverride: {
+    '& > div': {
+      background: 'transparent',
+    },
+  },
+}));
+
+const PopOverInnerContainer = styled('div')(({ theme }) => ({
+  // Adds space for "speechbubble tail"
+  position: 'relative',
+  background: '#262626',
+  borderRadius: '.4em',
+  marginLeft: '10px',
+}));
+
+const PopOverContentContainer = styled('div')(({ theme }) => ({
+  padding: theme.spacing(2),
+}));
+
+const PopOverLeftTail = styled('div')(({ theme }) => ({
+  content: ' ',
+  position: 'absolute',
+  left: '-20px',
+  top: '5px',
+  borderBottom: '10px solid transparent',
+  borderRight: '10px solid #262626',
+  borderLeft: '10px solid transparent',
+  borderTop: '10px solid transparent',
+}));
+
+const PopOverTitle = styled('div')({
+  color: '#F2F2F2',
+  fontSize: '20px',
+  fontWeight: 600,
+  lineHeight: '24px',
+});
+
+const PopOverSubtext = styled('div')({
+  color: '#BEBEBE',
+  fontSize: '16px',
+  marginTop: 0,
+});
+
+export const BUTTON_TYPE_BUTTON = 'button';
+export const BUTTON_TYPE_INFO = 'info';
+
+const BUTTON_TYPES = [BUTTON_TYPE_BUTTON, BUTTON_TYPE_INFO];
+
+interface PopOverProps {
+  buttonType?: typeof BUTTON_TYPES[number];
+  buttonCta?: string;
+  title?: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+  popOverId: string;
+}
+
+export default function PopOverWithButton({
+  buttonType,
+  buttonCta,
+  title,
+  subtitle,
+  children,
+  popOverId,
+}: PopOverProps) {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? popOverId : undefined;
+
+  let buttonComponent;
+  if (buttonType === BUTTON_TYPE_INFO) {
+    buttonComponent = (
+      <CardActionArea onClick={handleOpen}>
+        <InfoIcon />
+      </CardActionArea>
+    );
+  } else {
+    buttonComponent = (
+      <Button aria-describedby={id} variant="contained" color="primary" onClick={handleOpen}>
+        {buttonCta || 'Click me!'}
+      </Button>
+    );
+  }
+
+  return (
+    <div>
+      {buttonComponent}
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        className={classes.popOverOverride}
+        // The following makes the animation that has the pop-over come out the right of the button
+        // Change if we want it to come out another way
+        anchorOrigin={{
+          vertical: 'center',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'center',
+          horizontal: 'left',
+        }}
+      >
+        <PopOverInnerContainer>
+          <PopOverLeftTail />
+          <PopOverContentContainer>
+            {title && <PopOverTitle>{title}</PopOverTitle>}
+            {subtitle && <PopOverSubtext>{subtitle}</PopOverSubtext>}
+            {children}
+          </PopOverContentContainer>
+        </PopOverInnerContainer>
+      </Popover>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds room title to top row
- Creates popover/button component w/ "tail"
- Adds popover component with info button to menu bar
- Issue link : [LINK](https://github.com/carlosdp/lockdown-party/issues/10)

## Test
- locally

![PopoverVid](https://user-images.githubusercontent.com/2453344/77220343-7f277900-6b15-11ea-9247-e74181001242.gif)

## Reviewers
@carlosdp @nitsanshai @bradplax @RomanBaiocco 